### PR TITLE
F32 support

### DIFF
--- a/src/slice.rs
+++ b/src/slice.rs
@@ -147,7 +147,7 @@ pub fn fftshift<T: Copy + Default>(width: usize, height: usize, matrix: &[T]) ->
 pub mod dcst {
 
     use super::transpose;
-    use rustdct::DctPlanner;
+    use rustdct::{DctPlanner, DctNum};
 
     /// Compute the 2D cosine transform of an image buffer.
     ///
@@ -163,11 +163,11 @@ pub mod dcst {
     ///
     /// Remark: an allocation the size of the image buffer is performed for the transposition,
     /// as well as a scratch buffer while performing the rows and columns transforms.
-    pub fn dct_2d(width: usize, height: usize, img_buffer: &mut [f64]) {
+    pub fn dct_2d<T: DctNum + Copy + Default>(width: usize, height: usize, img_buffer: &mut [T]) {
         // Compute the FFT of each row of the image.
         let mut planner = DctPlanner::new();
         let dct_width = planner.plan_dct2(width);
-        let mut scratch = vec![0.0; dct_width.get_scratch_len()];
+        let mut scratch = vec![T::default(); dct_width.get_scratch_len()];
         for row_buffer in img_buffer.chunks_exact_mut(width) {
             dct_width.process_dct2_with_scratch(row_buffer, &mut scratch);
         }
@@ -175,7 +175,7 @@ pub mod dcst {
         // Transpose the image to be able to compute the FFT on the other dimension.
         let mut transposed = transpose(width, height, img_buffer);
         let dct_height = planner.plan_dct2(height);
-        scratch.resize(dct_height.get_scratch_len(), 0.0);
+        scratch.resize(dct_height.get_scratch_len(), T::default());
         for column_buffer in transposed.chunks_exact_mut(height) {
             dct_height.process_dct2_with_scratch(column_buffer, &mut scratch);
         }
@@ -187,7 +187,7 @@ pub mod dcst {
     /// This uses rayon internally, see the rayon crate docs to control the level
     /// of parallelism.
     #[cfg(feature = "parallel")]
-    pub fn par_dct_2d(width: usize, height: usize, img_buffer: &mut [f64]) {
+    pub fn par_dct_2d<T: DctNum + Default>(width: usize, height: usize, img_buffer: &mut [T]) {
         use rayon::prelude::{ParallelIterator, ParallelSliceMut};
 
         let mut planner = DctPlanner::new();
@@ -225,11 +225,11 @@ pub mod dcst {
     ///
     /// Remark: an allocation the size of the image buffer is performed for the transposition,
     /// as well as a scratch buffer while performing the rows and columns transforms.
-    pub fn idct_2d(width: usize, height: usize, img_buffer: &mut [f64]) {
+    pub fn idct_2d<T: DctNum + Default>(width: usize, height: usize, img_buffer: &mut [T]) {
         // Compute the FFT of each row of the image.
         let mut planner = DctPlanner::new();
         let dct_width = planner.plan_dct3(width);
-        let mut scratch = vec![0.0; dct_width.get_scratch_len()];
+        let mut scratch = vec![T::default(); dct_width.get_scratch_len()];
         for row_buffer in img_buffer.chunks_exact_mut(width) {
             dct_width.process_dct3_with_scratch(row_buffer, &mut scratch);
         }
@@ -237,7 +237,7 @@ pub mod dcst {
         // Transpose the image to be able to compute the FFT on the other dimension.
         let mut transposed = transpose(width, height, img_buffer);
         let dct_height = planner.plan_dct3(height);
-        scratch.resize(dct_height.get_scratch_len(), 0.0);
+        scratch.resize(dct_height.get_scratch_len(), T::default());
         for column_buffer in transposed.chunks_exact_mut(height) {
             dct_height.process_dct3_with_scratch(column_buffer, &mut scratch);
         }
@@ -249,7 +249,7 @@ pub mod dcst {
     /// This uses rayon internally, see the rayon crate docs to control the level
     /// of parallelism.
     #[cfg(feature = "parallel")]
-    pub fn par_idct_2d(width: usize, height: usize, img_buffer: &mut [f64]) {
+    pub fn par_idct_2d<T: DctNum + Default>(width: usize, height: usize, img_buffer: &mut [T]) {
         use rayon::prelude::{ParallelIterator, ParallelSliceMut};
 
         let mut planner = DctPlanner::new();


### PR DESCRIPTION
This my try for #4.

The first commit implements it only for the FFT in the slice module which is the only case I'm interested to use, but I also tried to do it for the entire library in the second commit.

Regarding the first commit:

- I had to add the Default trait because it was used in some functions. An alternative I think is to replace every `T::default()` with a `T::zero()` since `FftNum` implements the `Zero` trait
- I added a quick test to see if at least is compiles for f32 and f64

Regarding the second commit:

- Apparently for ndarray module we also need the Clone trait, unless we change a bit the code
- Something similar happens in the slice::dct where we need Copy, but I guess it is fixable

Anyway, I leave up to you to think if adding all of these parametrizations make sense. I wonder if this change will make problems for users since we are changing the API. Maybe we can modify things a bit so we do not need the Default, Copy and Clone traits, leaving only the FftNum and DctNum traits as required

In any case, I'm just evaluating Rust for some application and needed f32 2D FFTs support, if there is no interest in this I guess I will make a small fork that only includes the 5 functions of the slice module

Thank you in any case!